### PR TITLE
Add missing closing bracket to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ const importUpload = importCredentials
         (err, data) => err ? reject(err) : resolve(data)
       );
     })
+  })
   .then(printRet('Upload file'))
   .catch(errExit('Upload file'));
 


### PR DESCRIPTION
I've added a missing closing bracket and paren in the readme.